### PR TITLE
Refactored wrap functions

### DIFF
--- a/src/builtin/main.ts
+++ b/src/builtin/main.ts
@@ -1,4 +1,4 @@
 export * from './number-compare';
 export * from './number';
 export * from './string';
-export { Arg } from './util';
+export * from './wrap';

--- a/src/builtin/number-compare.ts
+++ b/src/builtin/number-compare.ts
@@ -7,7 +7,7 @@ import {
     StructType,
 } from '../types';
 import { union } from '../union';
-import { Arg, wrapBinary } from './util';
+import { Arg, wrapBinary } from './wrap';
 
 type NonNan = NumericLiteralType | IntervalType | IntIntervalType;
 const handleNan = (
@@ -93,7 +93,7 @@ const lessThenReal = (a: NonNan, b: NonNan): Arg<StructType> => {
     }
     return BOOL_FALSE;
 };
-export const lessThan = wrapBinary<NumberPrimitive, StructType>((a, b) => {
+export const lessThan = wrapBinary((a: NumberPrimitive, b: NumberPrimitive) => {
     const aNan = handleNan(a);
     const bNan = handleNan(b);
 
@@ -117,7 +117,7 @@ const lessThenEqualReal = (a: NonNan, b: NonNan): Arg<StructType> => {
     }
     return BOOL_FALSE;
 };
-export const lessThanEqual = wrapBinary<NumberPrimitive, StructType>((a, b) => {
+export const lessThanEqual = wrapBinary((a: NumberPrimitive, b: NumberPrimitive) => {
     const aNan = handleNan(a);
     const bNan = handleNan(b);
 

--- a/src/builtin/number.ts
+++ b/src/builtin/number.ts
@@ -9,17 +9,8 @@ import {
 } from '../types';
 import { intInterval, interval, literal } from '../types-util';
 import { union } from '../union';
-import {
-    Arg,
-    BinaryFn,
-    UnaryFn,
-    fixRoundingError,
-    isSmallIntInterval,
-    mapSmallIntInterval,
-    wrapBinary,
-    wrapUnary,
-    wrapVarArgs,
-} from './util';
+import { fixRoundingError, isSmallIntInterval, mapSmallIntInterval } from './util';
+import { Arg, BinaryFn, UnaryFn, wrapBinary, wrapReducerVarArgs, wrapUnary } from './wrap';
 
 const addLiteral = (a: NumericLiteralType, b: NumberPrimitive): Arg<NumberPrimitive> => {
     if (Number.isNaN(a.value)) return a;
@@ -55,7 +46,7 @@ const addLiteral = (a: NumericLiteralType, b: NumberPrimitive): Arg<NumberPrimit
 
     return new IntervalType(min, max);
 };
-export const add = wrapVarArgs(ZERO, (a: NumberPrimitive, b: NumberPrimitive) => {
+export const add = wrapReducerVarArgs(ZERO, (a: NumberPrimitive, b: NumberPrimitive) => {
     if (a.type === 'literal') return addLiteral(a, b);
     if (b.type === 'literal') return addLiteral(b, a);
 
@@ -140,7 +131,7 @@ const multiplyLiteral = (a: NumericLiteralType, b: NumberPrimitive): Arg<NumberP
     if (a.value < 0) return interval(max, min);
     return interval(min, max);
 };
-export const multiply = wrapVarArgs(ONE, (a: NumberPrimitive, b: NumberPrimitive) => {
+export const multiply = wrapReducerVarArgs(ONE, (a: NumberPrimitive, b: NumberPrimitive) => {
     if (a.type === 'literal') return multiplyLiteral(a, b);
     if (b.type === 'literal') return multiplyLiteral(b, a);
 
@@ -300,7 +291,7 @@ const minimumIntInterval = (
     const intMax = Number.isInteger(b.min) ? b.min - 1 : Math.floor(b.min);
     return union(intInterval(a.min, intMax), interval(b.min, Math.min(a.max, b.max)));
 };
-export const minimum = wrapVarArgs(INF, (a: NumberPrimitive, b: NumberPrimitive) => {
+export const minimum = wrapReducerVarArgs(INF, (a: NumberPrimitive, b: NumberPrimitive) => {
     if (a.type === 'literal') return minimumLiteral(a, b);
     if (b.type === 'literal') return minimumLiteral(b, a);
 
@@ -312,7 +303,7 @@ export const minimum = wrapVarArgs(INF, (a: NumberPrimitive, b: NumberPrimitive)
 
     return new IntervalType(Math.min(a.min, b.min), Math.min(a.max, b.max));
 });
-export const maximum = wrapVarArgs(NEG_INF, (a: NumberPrimitive, b: NumberPrimitive) => {
+export const maximum = wrapReducerVarArgs(NEG_INF, (a: NumberPrimitive, b: NumberPrimitive) => {
     return negate(minimum(negate(a), negate(b)));
 });
 

--- a/src/builtin/string.ts
+++ b/src/builtin/string.ts
@@ -1,5 +1,5 @@
 import { NumberPrimitive, StringLiteralType, StringPrimitive, StringType } from '../types';
-import { wrapUnary, wrapVarArgs } from './util';
+import { wrapReducerVarArgs, wrapUnary } from './wrap';
 
 export const toString = wrapUnary<StringPrimitive | NumberPrimitive, StringPrimitive>((a) => {
     if (a.underlying === 'string') return a;
@@ -15,7 +15,7 @@ export const toString = wrapUnary<StringPrimitive | NumberPrimitive, StringPrimi
     return StringType.instance;
 });
 
-export const concat = wrapVarArgs(new StringLiteralType(''), (a, b) => {
+export const concat = wrapReducerVarArgs(new StringLiteralType(''), (a, b) => {
     if (a.type === 'literal' && b.type === 'literal') {
         return new StringLiteralType(a.value + b.value);
     }

--- a/src/builtin/util.ts
+++ b/src/builtin/util.ts
@@ -1,12 +1,6 @@
-import {
-    IntIntervalType,
-    NeverType,
-    NumberPrimitive,
-    StringPrimitive,
-    UnionType,
-    ValueType,
-} from '../types';
+import { IntIntervalType, NumberPrimitive } from '../types';
 import { union } from '../union';
+import { Arg } from './wrap';
 
 export const fixRoundingError = (n: number): number => {
     if (!Number.isFinite(n)) return n;
@@ -23,83 +17,6 @@ export const fixRoundingError = (n: number): number => {
     }
     return n;
 };
-
-export type Arg<T extends ValueType> = T | UnionType<T> | NeverType;
-
-export type UnaryFn<T extends ValueType, R extends ValueType = T> = (a: Arg<T>) => Arg<R>;
-export type BinaryFn<T extends ValueType, R extends ValueType = T> = (
-    a: Arg<T>,
-    b: Arg<T>
-) => Arg<R>;
-export type VarArgsFn<T extends ValueType> = (...args: Arg<T>[]) => Arg<T>;
-
-export function wrapUnary(
-    fn: (a: StringPrimitive) => Arg<StringPrimitive>
-): UnaryFn<StringPrimitive>;
-export function wrapUnary(
-    fn: (a: NumberPrimitive) => Arg<NumberPrimitive>
-): UnaryFn<NumberPrimitive>;
-export function wrapUnary<T extends ValueType, R extends ValueType = T>(
-    fn: (a: T) => Arg<R>
-): UnaryFn<T, R>;
-// eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions
-export function wrapUnary<T extends ValueType, R extends ValueType = T>(
-    fn: (a: T) => Arg<R>
-): UnaryFn<T, R> {
-    return (a) => {
-        if (a.type === 'never') return NeverType.instance;
-        if (a.type === 'union') return union(...a.items.map(fn)) as Arg<R>;
-        return fn(a);
-    };
-}
-export const wrapBinary = <T extends ValueType, R extends ValueType = T>(
-    fn: (a: T, b: T) => Arg<R>
-): BinaryFn<T, R> => {
-    return (a, b) => {
-        if (a.type === 'never' || b.type === 'never') return NeverType.instance;
-        if (a.type === 'union') {
-            if (b.type !== 'union') {
-                return union(...a.items.map((aItem) => fn(aItem, b))) as Arg<R>;
-            }
-
-            const items: Arg<R>[] = [];
-            for (const aItem of a.items) {
-                for (const bItem of b.items) {
-                    items.push(fn(aItem, bItem));
-                }
-            }
-            return union(...items) as Arg<R>;
-        }
-        if (b.type === 'union') {
-            return union(...b.items.map((bItem) => fn(a, bItem))) as Arg<R>;
-        }
-        return fn(a, b);
-    };
-};
-
-export function wrapVarArgs(
-    neutral: Arg<StringPrimitive>,
-    fn: (a: StringPrimitive, b: StringPrimitive) => Arg<StringPrimitive>
-): VarArgsFn<StringPrimitive>;
-export function wrapVarArgs(
-    neutral: Arg<NumberPrimitive>,
-    fn: (a: NumberPrimitive, b: NumberPrimitive) => Arg<NumberPrimitive>
-): VarArgsFn<NumberPrimitive>;
-// eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions
-export function wrapVarArgs<T extends ValueType>(
-    neutral: Arg<T>,
-    fn: (a: T, b: T) => Arg<T>
-): VarArgsFn<T> {
-    const binary = wrapBinary(fn);
-    return (...args) => {
-        if (args.length === 0) return neutral;
-        let result = args[0];
-        for (let i = 1; i < args.length; i += 1) {
-            result = binary(result, args[i]);
-        }
-        return result;
-    };
-}
 
 export const isSmallIntInterval = (type: IntIntervalType): boolean => {
     return type.max - type.min <= 10;

--- a/src/builtin/wrap.ts
+++ b/src/builtin/wrap.ts
@@ -1,0 +1,164 @@
+import { NeverType, NumberPrimitive, StringPrimitive, UnionType, ValueType } from '../types';
+import { union } from '../union';
+import { EMPTY_ARRAY } from '../util';
+
+export type Arg<T extends ValueType> = T | UnionType<T> | NeverType;
+
+export type UnaryFn<A extends ValueType, R extends ValueType = A> = (a: Arg<A>) => Arg<R>;
+export type BinaryFn<A extends ValueType, B extends ValueType = A, R extends ValueType = A & B> = (
+    a: Arg<A>,
+    b: Arg<B>
+) => Arg<R>;
+export type TernaryFn<
+    A extends ValueType,
+    B extends ValueType = A,
+    C extends ValueType = B,
+    R extends ValueType = A & B & C
+> = (a: Arg<A>, b: Arg<B>, c: Arg<C>) => Arg<R>;
+export type QuaternaryFn<
+    A extends ValueType,
+    B extends ValueType = A,
+    C extends ValueType = B,
+    D extends ValueType = C,
+    R extends ValueType = A & B & C & D
+> = (a: Arg<A>, b: Arg<B>, c: Arg<C>, d: Arg<D>) => Arg<R>;
+
+const toValues = <T extends ValueType>(arg: Arg<T>): readonly T[] => {
+    if (arg.type === 'never') {
+        return EMPTY_ARRAY;
+    }
+    if (arg.type === 'union') {
+        return arg.items;
+    }
+    return [arg];
+};
+
+export function wrapUnary(
+    fn: (a: StringPrimitive) => Arg<StringPrimitive>
+): UnaryFn<StringPrimitive>;
+export function wrapUnary(
+    fn: (a: NumberPrimitive) => Arg<NumberPrimitive>
+): UnaryFn<NumberPrimitive>;
+export function wrapUnary<A extends ValueType, R extends ValueType = A>(
+    fn: (a: A) => Arg<R>
+): UnaryFn<A, R>;
+// eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions
+export function wrapUnary<T extends ValueType, R extends ValueType = T>(
+    fn: (a: T) => Arg<R>
+): UnaryFn<T, R> {
+    return (a) => {
+        if (a.type === 'never') return NeverType.instance;
+        if (a.type === 'union') return union(...a.items.map(fn)) as Arg<R>;
+        return fn(a);
+    };
+}
+
+export const wrapBinary = <
+    A extends ValueType,
+    B extends ValueType = A,
+    R extends ValueType = A & B
+>(
+    fn: (a: A, b: B) => Arg<R>
+): BinaryFn<A, B, R> => {
+    return (a, b) => {
+        if (a.type === 'never' || b.type === 'never') return NeverType.instance;
+
+        const aValues = toValues(a);
+        const bValues = toValues(b);
+        const items: Arg<R>[] = [];
+        for (const aItem of aValues) {
+            for (const bItem of bValues) {
+                items.push(fn(aItem, bItem));
+            }
+        }
+        return union(...items) as Arg<R>;
+    };
+};
+
+export const wrapTernary = <
+    A extends ValueType,
+    B extends ValueType = A,
+    C extends ValueType = B,
+    R extends ValueType = A & B & C
+>(
+    fn: (a: A, b: B, c: C) => Arg<R>
+): TernaryFn<A, B, C, R> => {
+    return (a, b, c) => {
+        if (a.type === 'never' || b.type === 'never' || c.type === 'never')
+            return NeverType.instance;
+
+        const aValues = toValues(a);
+        const bValues = toValues(b);
+        const cValues = toValues(c);
+        const items: Arg<R>[] = [];
+        for (const aItem of aValues) {
+            for (const bItem of bValues) {
+                for (const cItem of cValues) {
+                    items.push(fn(aItem, bItem, cItem));
+                }
+            }
+        }
+        return union(...items) as Arg<R>;
+    };
+};
+
+export const wrapQuaternary = <
+    A extends ValueType,
+    B extends ValueType = A,
+    C extends ValueType = B,
+    D extends ValueType = C,
+    R extends ValueType = A & B & C & D
+>(
+    fn: (a: A, b: B, c: C, d: D) => Arg<R>
+): QuaternaryFn<A, B, C, D, R> => {
+    return (a, b, c, d) => {
+        if (a.type === 'never' || b.type === 'never' || c.type === 'never' || d.type === 'never')
+            return NeverType.instance;
+
+        const aValues = toValues(a);
+        const bValues = toValues(b);
+        const cValues = toValues(c);
+        const dValues = toValues(d);
+        const items: Arg<R>[] = [];
+        for (const aItem of aValues) {
+            for (const bItem of bValues) {
+                for (const cItem of cValues) {
+                    for (const dItem of dValues) {
+                        items.push(fn(aItem, bItem, cItem, dItem));
+                    }
+                }
+            }
+        }
+        return union(...items) as Arg<R>;
+    };
+};
+
+export type ReducerVarArgsFn<T extends ValueType> = (...args: Arg<T>[]) => Arg<T>;
+
+export function wrapReducerVarArgs(
+    neutral: Arg<StringPrimitive>,
+    fn: (a: StringPrimitive, b: StringPrimitive) => Arg<StringPrimitive>
+): ReducerVarArgsFn<StringPrimitive>;
+export function wrapReducerVarArgs(
+    neutral: Arg<NumberPrimitive>,
+    fn: (a: NumberPrimitive, b: NumberPrimitive) => Arg<NumberPrimitive>
+): ReducerVarArgsFn<NumberPrimitive>;
+export function wrapReducerVarArgs<T extends ValueType>(
+    neutral: Arg<T>,
+    fn: (a: T, b: T) => Arg<T>
+): ReducerVarArgsFn<T>;
+// eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions
+export function wrapReducerVarArgs<T extends ValueType>(
+    neutral: Arg<T>,
+    fn: (a: T, b: T) => Arg<T>
+): ReducerVarArgsFn<T> {
+    const binary = wrapBinary(fn);
+    return (...args) => {
+        if (args.length === 0) return neutral;
+        let result = args[0];
+        for (let i = 1; i < args.length; i += 1) {
+            result = binary(result, args[i]);
+        }
+        return result;
+    };
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+export const EMPTY_ARRAY: readonly never[] = [];
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = () => {};
 


### PR DESCRIPTION
I refactored the wrap types and functions a bit. The implementation of those functions a bit simpler now and I added ternary and quaternary versions. Those functions should cover things like the `pad*` functions I recently added in chainner.

I also renamed `wrapVarargs` to `wrapReducerVarArgs`. The function isn't a general var args function, so this was a bit of a misnomer anyway.