### PR TITLE
Added value equality

### DIFF
--- a/src/builtin/any.ts
+++ b/src/builtin/any.ts
@@ -1,0 +1,22 @@
+import { BOOL, BOOL_FALSE, BOOL_TRUE } from '../constants';
+import { NeverType, StructType, Type } from '../types';
+import { valueEqual } from '../value-equal';
+import { Arg } from './wrap';
+
+export const equal = (a: Type, b: Type): Arg<StructType> => {
+    const { someEqual, someNotEqual } = valueEqual(a, b);
+
+    if (someEqual) {
+        if (someNotEqual) {
+            return BOOL;
+        } else {
+            return BOOL_TRUE;
+        }
+    } else {
+        if (someNotEqual) {
+            return BOOL_FALSE;
+        } else {
+            return NeverType.instance;
+        }
+    }
+};

--- a/src/builtin/main.ts
+++ b/src/builtin/main.ts
@@ -1,6 +1,7 @@
+export * from './any';
+export * from './bool';
 export * from './number-compare';
 export * from './number';
 export * from './string';
-export * from './bool';
 export * from './wrap';
 export { handleNumberLiterals } from './util';

--- a/src/global-scope.ts
+++ b/src/global-scope.ts
@@ -1,3 +1,4 @@
+import { equal } from './builtin/any';
 import { and, or } from './builtin/bool';
 import {
     abs,
@@ -62,9 +63,6 @@ builder.add(binary('string::includes', includes, StringType.instance, StringType
 builder.add(binary('string::startsWith', startsWith, StringType.instance, StringType.instance));
 builder.add(binary('string::endsWith', endsWith, StringType.instance, StringType.instance));
 
-builder.add(varArgs('bool::and', and, BOOL));
-builder.add(varArgs('bool::or', or, BOOL));
-
 // function for syntax desugaring
 builder.add(unary('number::neg', negate, NumberType.instance));
 builder.add(varArgs('number::add', add, NumberType.instance));
@@ -74,6 +72,11 @@ builder.add(binary('number::div', divide, NumberType.instance, NumberType.instan
 builder.add(unary('number::rec', reciprocal, NumberType.instance));
 builder.add(binary('number::lt', lessThan, NumberType.instance, NumberType.instance));
 builder.add(binary('number::lte', lessThanEqual, NumberType.instance, NumberType.instance));
+
+builder.add(varArgs('bool::and', and, BOOL));
+builder.add(varArgs('bool::or', or, BOOL));
+
+builder.add(binary('any::eq', equal, AnyType.instance, AnyType.instance));
 
 const code = `
 // invStrSet is an interesting function, because it cannot be a built-in function.
@@ -95,6 +98,8 @@ struct false;
 let bool = true | false;
 
 def bool::not(value: bool): bool = match value { true => false, false => true };
+
+def any::neq(a: any, b: any) = bool::not(any::eq(a, b));
 
 def number::gte(a: number, b: number): bool = number::lte(b, a);
 def number::gt(a: number, b: number): bool = number::lt(b, a);

--- a/src/value-equal.ts
+++ b/src/value-equal.ts
@@ -1,0 +1,126 @@
+import { isDisjointWith } from './intersection';
+import { NumberPrimitive, StringPrimitive, Type } from './types';
+import { assertNever } from './util';
+
+const valueCountNumber = (t: NumberPrimitive): number => {
+    switch (t.type) {
+        case 'number':
+            return Infinity;
+        case 'literal':
+            return 1;
+        case 'interval':
+            return Infinity;
+        case 'int-interval':
+            return t.max - t.min + 1;
+        default:
+            return assertNever(t);
+    }
+};
+const valueCountString = (t: StringPrimitive): number => {
+    switch (t.type) {
+        case 'string':
+            return Infinity;
+        case 'literal':
+            return 1;
+        case 'inverted-set':
+            return Infinity;
+        default:
+            return assertNever(t);
+    }
+};
+
+/**
+ * Returns how many values the set represented by the given type contains.
+ */
+const valueCount = (t: Type): number => {
+    switch (t.underlying) {
+        case 'never':
+            return 0;
+        case 'any':
+            return Infinity;
+        case 'number':
+            return valueCountNumber(t);
+        case 'string':
+            return valueCountString(t);
+        case 'struct': {
+            let total = 1;
+            for (const field of t.fields) {
+                total *= valueCount(field.type);
+                if (total === Infinity) break;
+            }
+            return total;
+        }
+        case 'union': {
+            let total = 0;
+            for (const item of t.items) {
+                total += valueCount(item);
+                if (total === Infinity) break;
+            }
+            return total;
+        }
+        default:
+            return assertNever(t);
+    }
+};
+
+export interface ValueEquality {
+    readonly someEqual: boolean;
+    readonly someNotEqual: boolean;
+}
+
+const NEITHER: ValueEquality = { someEqual: false, someNotEqual: false };
+const SOME_EQUAL: ValueEquality = { someEqual: true, someNotEqual: false };
+const SOME_NOT_EQUAL: ValueEquality = { someEqual: false, someNotEqual: true };
+const BOTH: ValueEquality = { someEqual: true, someNotEqual: true };
+
+/**
+ * Returns the result of comparing all accepted values of one type against all
+ * accepted values of another type.
+ *
+ * In Navi, types represent sets of values. E.g. `int` represents the set of
+ * all integers (ignoring implementation limitations). While most operations
+ * can be thought of in terms of what is done with those sets, this operation
+ * must the thought of in terms of the individual values those sets contain.
+ * When comparing 2 types, this operation is **different** from type equality.
+ *
+ * Conceptually, this function implements this algorithm (*):
+ *
+ * ```ts
+ * let someEqual = false;
+ * let someNotEqual = false;
+ * for (const aValue in iterateValues(a)) {
+ *   for (const bValue in iterateValues(b)) {
+ *     if (aValue === bValue) {
+ *       someEqual = true;
+ *     } else {
+ *       someNotEqual = true;
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * (*) We don't actually use `===` for equality because of NaN.
+ */
+export const valueEqual = (a: Type, b: Type): ValueEquality => {
+    if (a.type === 'never' || b.type === 'never') {
+        // if a or b is never, then we don't have values to compare to on one side
+        return NEITHER;
+    }
+
+    // at this point, we know that both a and b have at least one value each
+
+    if (isDisjointWith(a, b)) {
+        // we know that there are no values that are equal
+        return SOME_NOT_EQUAL;
+    }
+
+    // at this point, we know that some values are equal
+
+    if (valueCount(a) === 1 && valueCount(b) === 1) {
+        // since both side only have one value,
+        // we know that there is no combination that is not equal
+        return SOME_EQUAL;
+    }
+
+    return BOTH;
+};

--- a/tests/__snapshots__/evaluate.test.ts.snap
+++ b/tests/__snapshots__/evaluate.test.ts.snap
@@ -41,6 +41,34 @@ abs(never) => never
 abs(any) => Error: Incompatible argument type: The supplied argument type any is not compatible with the definition type."
 `;
 
+exports[`Builtin functions any::eq evaluate 1`] = `
+"any::eq(false, false) => true
+any::eq(false, true) => false
+any::eq(false, false | true) => false | true
+any::eq(false, never) => never
+any::eq(false, any) => false | true
+any::eq(true, false) => false
+any::eq(true, true) => true
+any::eq(true, false | true) => false | true
+any::eq(true, never) => never
+any::eq(true, any) => false | true
+any::eq(false | true, false) => false | true
+any::eq(false | true, true) => false | true
+any::eq(false | true, false | true) => false | true
+any::eq(false | true, never) => never
+any::eq(false | true, any) => false | true
+any::eq(never, false) => never
+any::eq(never, true) => never
+any::eq(never, false | true) => never
+any::eq(never, never) => never
+any::eq(never, any) => never
+any::eq(any, false) => false | true
+any::eq(any, true) => false | true
+any::eq(any, false | true) => false | true
+any::eq(any, never) => never
+any::eq(any, any) => false | true"
+`;
+
 exports[`Builtin functions bool::and evaluate 1`] = `
 "bool::and(false, false) => false
 bool::and(false, true) => false

--- a/tests/evaluate.test.ts
+++ b/tests/evaluate.test.ts
@@ -223,6 +223,8 @@ describe('Builtin functions', () => {
     testBinary('bool::and', bools);
     testBinary('bool::or', bools);
     testUnary('bool::not', bools);
+
+    testBinary('any::eq', [...bools, NeverType.instance, AnyType.instance]);
 });
 
 describe('Match', () => {


### PR DESCRIPTION
This adds a value equality function called `any::eq`. This function **does not** return whether the given types are equal, it returns whether the values in the set represented by the types are equal.

I will use `a == b` to mean `any::eq(a, b)` in the following examples:
```
1 == 1          // true
"foo" == "foo"  // true
1 == 2          // false
"foo" == "bar"  // false
"foo" == 1      // false
int == 0.5      // false (no integer is equal to 0.5)
int == 1        // true | false (1 is equal to 1 and all other integers are not equal to 1)
int == int      // true | false
1 == any        // true | false
1 == never      // never
```

