### PR TITLE
Fixed export of builtin

### DIFF
--- a/src/builtin/main.ts
+++ b/src/builtin/main.ts
@@ -1,7 +1,14 @@
-export * from './any';
-export * from './bool';
-export * from './number-compare';
-export * from './number';
-export * from './string';
+import { StringPrimitive } from '../types';
+import { concat } from './string';
+import { ReducerVarArgsFn } from './wrap';
+
 export * from './wrap';
 export { handleNumberLiterals } from './util';
+
+const Intrinsic = {
+    // the type cast is necessary to work around a bug in parcel
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    concat: concat as ReducerVarArgsFn<StringPrimitive>,
+} as const;
+
+export { Intrinsic };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,9 @@
-import * as builtin_ from './builtin/main';
-
+export * from './builtin/main';
 export * from './evaluate';
 export * from './expression';
 export * from './scope';
 export * from './source';
 export * from './types';
-
-// work around because parcel doesn't support `export * as name` after over 2 years.
-export const builtin = { ...builtin_ };
-
 export { getReferences } from './expression-util';
 export { globalScope } from './global-scope';
 export {


### PR DESCRIPTION
The export workaround didn't work for types, so I changed strategies. We now export generally useful functions from `src/builtin` and a few intrinsic function implementations via the `Intrinsic` object.