### PR TITLE
Inlined antlr4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,17 @@
       "name": "@chainner/navi",
       "version": "0.4.1",
       "license": "MIT",
-      "dependencies": {
-        "antlr4": "^4.11.0"
-      },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-replace": "^5.0.2",
+        "@rollup/plugin-run": "^3.0.1",
         "@rollup/plugin-typescript": "^11.0.0",
         "@types/antlr4": "^4.7.3",
         "@types/jest": "^29.1.1",
         "@types/node": "^18.14.1",
         "@typescript-eslint/eslint-plugin": "^5.39.0",
         "@typescript-eslint/parser": "^5.39.0",
+        "antlr4": "^4.11.0",
         "eslint": "^8.24.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^3.5.1",
@@ -1266,6 +1265,32 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-run": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-run/-/plugin-run-3.0.1.tgz",
+      "integrity": "sha512-wbYR1Ahz8ohYnlyXzpBTwhGWfs+OO/uZMjgpDGr8AgnL/XfoTbO7BuNYY8ncR/j/1dhCJo+NDuTRkIeCxE434Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "14.18.30"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-run/node_modules/@types/node": {
+      "version": "14.18.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.30.tgz",
+      "integrity": "sha512-8OEyg4oc/CqN5+LbInKNLA8MfbGzbC+k8lVPePXazuwEVrVeQ9gwMDX00HJwWbC7syc1FWRU6Mow0Lm+mibHAQ==",
+      "dev": true
+    },
     "node_modules/@rollup/plugin-typescript": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
@@ -1807,6 +1832,7 @@
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.11.0.tgz",
       "integrity": "sha512-GUGlpE2JUjAN+G8G5vY+nOoeyNhHsXoIJwP1XF1oRw89vifA1K46T6SEkwLwr7drihN7I/lf0DIjKc4OZvBX8w==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -7173,6 +7199,23 @@
         "magic-string": "^0.27.0"
       }
     },
+    "@rollup/plugin-run": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-run/-/plugin-run-3.0.1.tgz",
+      "integrity": "sha512-wbYR1Ahz8ohYnlyXzpBTwhGWfs+OO/uZMjgpDGr8AgnL/XfoTbO7BuNYY8ncR/j/1dhCJo+NDuTRkIeCxE434Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "14.18.30"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.30.tgz",
+          "integrity": "sha512-8OEyg4oc/CqN5+LbInKNLA8MfbGzbC+k8lVPePXazuwEVrVeQ9gwMDX00HJwWbC7syc1FWRU6Mow0Lm+mibHAQ==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/plugin-typescript": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
@@ -7560,7 +7603,8 @@
     "antlr4": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.11.0.tgz",
-      "integrity": "sha512-GUGlpE2JUjAN+G8G5vY+nOoeyNhHsXoIJwP1XF1oRw89vifA1K46T6SEkwLwr7drihN7I/lf0DIjKc4OZvBX8w=="
+      "integrity": "sha512-GUGlpE2JUjAN+G8G5vY+nOoeyNhHsXoIJwP1XF1oRw89vifA1K46T6SEkwLwr7drihN7I/lf0DIjKc4OZvBX8w==",
+      "dev": true
     },
     "anymatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.1",
   "description": "A set-theory based type system used in chaiNNer",
   "main": "./dist/main.js",
-  "module": "./dist/module.js",
+  "module": "./dist/module.mjs",
   "types": "./dist/main.d.ts",
   "exports": "./dist/main.js",
   "files": [
@@ -37,12 +37,14 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.2",
+    "@rollup/plugin-run": "^3.0.1",
     "@rollup/plugin-typescript": "^11.0.0",
     "@types/antlr4": "^4.7.3",
     "@types/jest": "^29.1.1",
     "@types/node": "^18.14.1",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
+    "antlr4": "^4.11.0",
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.5.1",
@@ -59,8 +61,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
-  },
-  "dependencies": {
-    "antlr4": "^4.11.0"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,5 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
+import run from '@rollup/plugin-run';
 import typescript from '@rollup/plugin-typescript';
 import fs from 'fs';
 
@@ -8,7 +9,6 @@ const globalNavi = fs.readFileSync('src/global.navi', 'utf-8');
 /** @type {import("rollup").RollupOptions} */
 const config = {
     input: 'src/main.ts',
-    external: [/^antlr4$/],
     output: [
         {
             file: 'dist/main.js',
@@ -16,7 +16,7 @@ const config = {
             sourcemap: true,
         },
         {
-            file: 'dist/module.js',
+            file: 'dist/module.mjs',
             format: 'module',
             sourcemap: true,
         },
@@ -24,13 +24,15 @@ const config = {
     plugins: [
         replace({
             values: {
-                "import fs from 'fs'": '',
                 "fs.readFileSync(__dirname + '/global.navi', 'utf-8')": JSON.stringify(globalNavi),
             },
             delimiters: ['', ''],
         }),
         nodeResolve({ extensions: ['.mjs', '.js', '.json', '.ts'] }),
         typescript(),
+        run({
+            execArgv: ['-r', 'source-map-support/register'],
+        }),
     ],
 };
 


### PR DESCRIPTION
I finally found the problem. Both rollup and parcel generated incorrect CJS code. ANTLR4 uses a default export, which was not detected by either build tool. So instead of generating `const antlr4 = require('antlr4').default`, they generated `const antlr4 = require('antlr4')`.

I fixed this by making rollup inline the antlr4 dependency. So the bundle includes all antlr4 library code.