### PR TITLE
Removed generic parameter of `NonNeverType`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,8 @@ export type WithType<U extends Type['type'], T extends Type = Type> = T extends 
     : never;
 
 export type NonTrivialType = ValueType | UnionType;
-export type NonNeverType<T extends Type = Type> = Exclude<T, NeverType>;
+export type NonNeverType = Exclude<Type, NeverType>;
+export type NonNever<T extends Type> = Exclude<T, NeverType>;
 
 export enum Bounds {
     Inclusive = 0,

--- a/src/union.ts
+++ b/src/union.ts
@@ -8,7 +8,7 @@ import {
     InvertedStringSetType,
     NeverType,
     NonIntIntervalType,
-    NonNeverType,
+    NonNever,
     NonTrivialType,
     NumberPrimitive,
     NumberType,
@@ -516,8 +516,8 @@ type Closed<T extends Type> =
     | T;
 
 type Union2<A extends Type, B extends Type> =
-    | Closed<NonNeverType<A>>
-    | Closed<NonNeverType<B>>
+    | Closed<NonNever<A>>
+    | Closed<NonNever<B>>
     | (A extends NeverType ? (B extends NeverType ? NeverType : never) : never);
 type Union3<A extends Type, B extends Type, C extends Type> = Union2<A, Union2<B, C>>;
 type Union4<A extends Type, B extends Type, C extends Type, D extends Type> = Union2<


### PR DESCRIPTION
I split `NonNeverType<T>` into `NonNeverType` and `NonNever<T>` for simplicity.