### PR TITLE
Add `else if` chains

### DIFF
--- a/src/antlr4/Navi.g4
+++ b/src/antlr4/Navi.g4
@@ -54,7 +54,10 @@ named: name;
 structExpression: name fields;
 scopeExpression: '{' definition* expression '}';
 ifExpression:
-	If expression scopeExpression Else scopeExpression;
+	If expression scopeExpression Else (
+		scopeExpression
+		| ifExpression
+	);
 
 fieldAccessExpression: primaryExpression ('.' Identifier)*;
 

--- a/src/antlr4/NaviParser.js
+++ b/src/antlr4/NaviParser.js
@@ -2,7 +2,7 @@
 // jshint ignore: start
 import antlr4 from 'antlr4';
 import NaviListener from './NaviListener.js';
-const serializedATN = [4,1,48,375,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,
+const serializedATN = [4,1,48,377,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,
 4,2,5,7,5,2,6,7,6,2,7,7,7,2,8,7,8,2,9,7,9,2,10,7,10,2,11,7,11,2,12,7,12,
 2,13,7,13,2,14,7,14,2,15,7,15,2,16,7,16,2,17,7,17,2,18,7,18,2,19,7,19,2,
 20,7,20,2,21,7,21,2,22,7,22,2,23,7,23,2,24,7,24,2,25,7,25,2,26,7,26,2,27,
@@ -18,110 +18,111 @@ const serializedATN = [4,1,48,375,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,
 11,188,9,11,1,11,3,11,191,8,11,3,11,193,8,11,1,11,1,11,1,12,1,12,3,12,199,
 8,12,1,12,1,12,3,12,203,8,12,1,12,1,12,1,12,1,13,1,13,1,13,1,13,1,13,1,14,
 1,14,1,15,1,15,1,15,1,16,1,16,5,16,220,8,16,10,16,12,16,223,9,16,1,16,1,
-16,1,16,1,17,1,17,1,17,1,17,1,17,1,17,1,18,1,18,1,18,5,18,237,8,18,10,18,
-12,18,240,9,18,1,19,3,19,243,8,19,1,19,1,19,1,20,1,20,1,20,5,20,250,8,20,
-10,20,12,20,253,9,20,1,21,1,21,1,21,5,21,258,8,21,10,21,12,21,261,9,21,1,
-22,1,22,1,22,5,22,266,8,22,10,22,12,22,269,9,22,1,23,1,23,1,23,5,23,274,
-8,23,10,23,12,23,277,9,23,1,24,1,24,1,24,3,24,282,8,24,1,25,1,25,1,26,1,
-26,1,26,5,26,289,8,26,10,26,12,26,292,9,26,1,26,3,26,295,8,26,3,26,297,8,
-26,1,27,1,27,1,27,1,27,5,27,303,8,27,10,27,12,27,306,9,27,1,27,3,27,309,
-8,27,3,27,311,8,27,1,27,1,27,1,28,1,28,1,28,1,29,1,29,1,29,1,29,5,29,322,
-8,29,10,29,12,29,325,9,29,1,29,3,29,328,8,29,3,29,330,8,29,1,29,1,29,1,30,
-1,30,1,30,1,30,5,30,338,8,30,10,30,12,30,341,9,30,1,30,1,30,3,30,345,8,30,
-1,30,3,30,348,8,30,1,30,3,30,351,8,30,3,30,353,8,30,1,30,1,30,1,31,1,31,
-1,31,1,32,1,32,1,32,1,32,1,33,1,33,1,33,1,34,1,34,1,34,5,34,370,8,34,10,
-34,12,34,373,9,34,1,34,0,0,35,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,
-32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,0,3,1,0,37,38,1,
-0,35,36,1,0,39,44,396,0,74,1,0,0,0,2,82,1,0,0,0,4,88,1,0,0,0,6,90,1,0,0,
-0,8,103,1,0,0,0,10,105,1,0,0,0,12,111,1,0,0,0,14,124,1,0,0,0,16,133,1,0,
-0,0,18,154,1,0,0,0,20,176,1,0,0,0,22,178,1,0,0,0,24,198,1,0,0,0,26,207,1,
-0,0,0,28,212,1,0,0,0,30,214,1,0,0,0,32,217,1,0,0,0,34,227,1,0,0,0,36,233,
-1,0,0,0,38,242,1,0,0,0,40,246,1,0,0,0,42,254,1,0,0,0,44,262,1,0,0,0,46,270,
-1,0,0,0,48,278,1,0,0,0,50,283,1,0,0,0,52,296,1,0,0,0,54,298,1,0,0,0,56,314,
-1,0,0,0,58,317,1,0,0,0,60,333,1,0,0,0,62,356,1,0,0,0,64,359,1,0,0,0,66,363,
-1,0,0,0,68,366,1,0,0,0,70,73,3,8,4,0,71,73,3,4,2,0,72,70,1,0,0,0,72,71,1,
-0,0,0,73,76,1,0,0,0,74,72,1,0,0,0,74,75,1,0,0,0,75,77,1,0,0,0,76,74,1,0,
-0,0,77,78,5,0,0,1,78,1,1,0,0,0,79,81,3,8,4,0,80,79,1,0,0,0,81,84,1,0,0,0,
-82,80,1,0,0,0,82,83,1,0,0,0,83,85,1,0,0,0,84,82,1,0,0,0,85,86,3,50,25,0,
-86,87,5,0,0,1,87,3,1,0,0,0,88,89,3,6,3,0,89,5,1,0,0,0,90,91,5,22,0,0,91,
-92,5,15,0,0,92,93,3,68,34,0,93,95,3,60,30,0,94,96,3,66,33,0,95,94,1,0,0,
-0,95,96,1,0,0,0,96,97,1,0,0,0,97,98,5,1,0,0,98,7,1,0,0,0,99,104,3,10,5,0,
-100,104,3,12,6,0,101,104,3,14,7,0,102,104,3,16,8,0,103,99,1,0,0,0,103,100,
-1,0,0,0,103,101,1,0,0,0,103,102,1,0,0,0,104,9,1,0,0,0,105,106,5,20,0,0,106,
-109,3,68,34,0,107,110,5,1,0,0,108,110,3,54,27,0,109,107,1,0,0,0,109,108,
-1,0,0,0,110,11,1,0,0,0,111,112,5,15,0,0,112,113,3,68,34,0,113,115,3,58,29,
-0,114,116,3,66,33,0,115,114,1,0,0,0,115,116,1,0,0,0,116,122,1,0,0,0,117,
-118,5,2,0,0,118,119,3,50,25,0,119,120,5,1,0,0,120,123,1,0,0,0,121,123,3,
-32,16,0,122,117,1,0,0,0,122,121,1,0,0,0,123,13,1,0,0,0,124,125,5,16,0,0,
-125,127,3,68,34,0,126,128,3,66,33,0,127,126,1,0,0,0,127,128,1,0,0,0,128,
-129,1,0,0,0,129,130,5,2,0,0,130,131,3,50,25,0,131,132,5,1,0,0,132,15,1,0,
-0,0,133,134,5,21,0,0,134,135,3,68,34,0,135,149,5,3,0,0,136,141,3,18,9,0,
-137,138,5,4,0,0,138,140,3,18,9,0,139,137,1,0,0,0,140,143,1,0,0,0,141,139,
-1,0,0,0,141,142,1,0,0,0,142,145,1,0,0,0,143,141,1,0,0,0,144,146,5,4,0,0,
-145,144,1,0,0,0,145,146,1,0,0,0,146,148,1,0,0,0,147,136,1,0,0,0,148,151,
-1,0,0,0,149,147,1,0,0,0,149,150,1,0,0,0,150,152,1,0,0,0,151,149,1,0,0,0,
-152,153,5,5,0,0,153,17,1,0,0,0,154,156,5,34,0,0,155,157,3,54,27,0,156,155,
-1,0,0,0,156,157,1,0,0,0,157,19,1,0,0,0,158,177,5,26,0,0,159,177,5,27,0,0,
-160,177,5,28,0,0,161,177,5,29,0,0,162,177,5,30,0,0,163,177,5,31,0,0,164,
-177,5,32,0,0,165,177,5,33,0,0,166,177,3,22,11,0,167,177,3,34,17,0,168,177,
-3,26,13,0,169,177,3,28,14,0,170,177,3,30,15,0,171,177,3,32,16,0,172,173,
-5,6,0,0,173,174,3,50,25,0,174,175,5,7,0,0,175,177,1,0,0,0,176,158,1,0,0,
-0,176,159,1,0,0,0,176,160,1,0,0,0,176,161,1,0,0,0,176,162,1,0,0,0,176,163,
-1,0,0,0,176,164,1,0,0,0,176,165,1,0,0,0,176,166,1,0,0,0,176,167,1,0,0,0,
-176,168,1,0,0,0,176,169,1,0,0,0,176,170,1,0,0,0,176,171,1,0,0,0,176,172,
-1,0,0,0,177,21,1,0,0,0,178,179,5,17,0,0,179,180,3,50,25,0,180,192,5,3,0,
-0,181,186,3,24,12,0,182,183,5,4,0,0,183,185,3,24,12,0,184,182,1,0,0,0,185,
-188,1,0,0,0,186,184,1,0,0,0,186,187,1,0,0,0,187,190,1,0,0,0,188,186,1,0,
-0,0,189,191,5,4,0,0,190,189,1,0,0,0,190,191,1,0,0,0,191,193,1,0,0,0,192,
-181,1,0,0,0,192,193,1,0,0,0,193,194,1,0,0,0,194,195,5,5,0,0,195,23,1,0,0,
-0,196,199,5,25,0,0,197,199,3,50,25,0,198,196,1,0,0,0,198,197,1,0,0,0,199,
-202,1,0,0,0,200,201,5,14,0,0,201,203,5,34,0,0,202,200,1,0,0,0,202,203,1,
-0,0,0,203,204,1,0,0,0,204,205,5,8,0,0,205,206,3,50,25,0,206,25,1,0,0,0,207,
-208,3,68,34,0,208,209,5,6,0,0,209,210,3,52,26,0,210,211,5,7,0,0,211,27,1,
-0,0,0,212,213,3,68,34,0,213,29,1,0,0,0,214,215,3,68,34,0,215,216,3,54,27,
-0,216,31,1,0,0,0,217,221,5,3,0,0,218,220,3,8,4,0,219,218,1,0,0,0,220,223,
-1,0,0,0,221,219,1,0,0,0,221,222,1,0,0,0,222,224,1,0,0,0,223,221,1,0,0,0,
-224,225,3,50,25,0,225,226,5,5,0,0,226,33,1,0,0,0,227,228,5,18,0,0,228,229,
-3,50,25,0,229,230,3,32,16,0,230,231,5,19,0,0,231,232,3,32,16,0,232,35,1,
-0,0,0,233,238,3,20,10,0,234,235,5,9,0,0,235,237,5,34,0,0,236,234,1,0,0,0,
-237,240,1,0,0,0,238,236,1,0,0,0,238,239,1,0,0,0,239,37,1,0,0,0,240,238,1,
-0,0,0,241,243,5,35,0,0,242,241,1,0,0,0,242,243,1,0,0,0,243,244,1,0,0,0,244,
-245,3,36,18,0,245,39,1,0,0,0,246,251,3,38,19,0,247,248,7,0,0,0,248,250,3,
-38,19,0,249,247,1,0,0,0,250,253,1,0,0,0,251,249,1,0,0,0,251,252,1,0,0,0,
-252,41,1,0,0,0,253,251,1,0,0,0,254,259,3,40,20,0,255,256,7,1,0,0,256,258,
-3,40,20,0,257,255,1,0,0,0,258,261,1,0,0,0,259,257,1,0,0,0,259,260,1,0,0,
-0,260,43,1,0,0,0,261,259,1,0,0,0,262,267,3,42,21,0,263,264,5,10,0,0,264,
-266,3,42,21,0,265,263,1,0,0,0,266,269,1,0,0,0,267,265,1,0,0,0,267,268,1,
-0,0,0,268,45,1,0,0,0,269,267,1,0,0,0,270,275,3,44,22,0,271,272,5,11,0,0,
-272,274,3,44,22,0,273,271,1,0,0,0,274,277,1,0,0,0,275,273,1,0,0,0,275,276,
-1,0,0,0,276,47,1,0,0,0,277,275,1,0,0,0,278,281,3,46,23,0,279,280,7,2,0,0,
-280,282,3,46,23,0,281,279,1,0,0,0,281,282,1,0,0,0,282,49,1,0,0,0,283,284,
-3,48,24,0,284,51,1,0,0,0,285,290,3,50,25,0,286,287,5,4,0,0,287,289,3,50,
-25,0,288,286,1,0,0,0,289,292,1,0,0,0,290,288,1,0,0,0,290,291,1,0,0,0,291,
-294,1,0,0,0,292,290,1,0,0,0,293,295,5,4,0,0,294,293,1,0,0,0,294,295,1,0,
-0,0,295,297,1,0,0,0,296,285,1,0,0,0,296,297,1,0,0,0,297,53,1,0,0,0,298,310,
-5,3,0,0,299,304,3,56,28,0,300,301,5,4,0,0,301,303,3,56,28,0,302,300,1,0,
-0,0,303,306,1,0,0,0,304,302,1,0,0,0,304,305,1,0,0,0,305,308,1,0,0,0,306,
-304,1,0,0,0,307,309,5,4,0,0,308,307,1,0,0,0,308,309,1,0,0,0,309,311,1,0,
-0,0,310,299,1,0,0,0,310,311,1,0,0,0,311,312,1,0,0,0,312,313,5,5,0,0,313,
-55,1,0,0,0,314,315,5,34,0,0,315,316,3,66,33,0,316,57,1,0,0,0,317,329,5,6,
-0,0,318,323,3,62,31,0,319,320,5,4,0,0,320,322,3,62,31,0,321,319,1,0,0,0,
-322,325,1,0,0,0,323,321,1,0,0,0,323,324,1,0,0,0,324,327,1,0,0,0,325,323,
-1,0,0,0,326,328,5,4,0,0,327,326,1,0,0,0,327,328,1,0,0,0,328,330,1,0,0,0,
-329,318,1,0,0,0,329,330,1,0,0,0,330,331,1,0,0,0,331,332,5,7,0,0,332,59,1,
-0,0,0,333,352,5,6,0,0,334,339,3,62,31,0,335,336,5,4,0,0,336,338,3,62,31,
-0,337,335,1,0,0,0,338,341,1,0,0,0,339,337,1,0,0,0,339,340,1,0,0,0,340,344,
-1,0,0,0,341,339,1,0,0,0,342,343,5,4,0,0,343,345,3,64,32,0,344,342,1,0,0,
-0,344,345,1,0,0,0,345,348,1,0,0,0,346,348,3,64,32,0,347,334,1,0,0,0,347,
-346,1,0,0,0,348,350,1,0,0,0,349,351,5,4,0,0,350,349,1,0,0,0,350,351,1,0,
-0,0,351,353,1,0,0,0,352,347,1,0,0,0,352,353,1,0,0,0,353,354,1,0,0,0,354,
-355,5,7,0,0,355,61,1,0,0,0,356,357,5,34,0,0,357,358,3,66,33,0,358,63,1,0,
-0,0,359,360,5,45,0,0,360,361,5,34,0,0,361,362,3,66,33,0,362,65,1,0,0,0,363,
-364,5,12,0,0,364,365,3,50,25,0,365,67,1,0,0,0,366,371,5,34,0,0,367,368,5,
-13,0,0,368,370,5,34,0,0,369,367,1,0,0,0,370,373,1,0,0,0,371,369,1,0,0,0,
-371,372,1,0,0,0,372,69,1,0,0,0,373,371,1,0,0,0,42,72,74,82,95,103,109,115,
-122,127,141,145,149,156,176,186,190,192,198,202,221,238,242,251,259,267,
-275,281,290,294,296,304,308,310,323,327,329,339,344,347,350,352,371];
+16,1,16,1,17,1,17,1,17,1,17,1,17,1,17,3,17,234,8,17,1,18,1,18,1,18,5,18,
+239,8,18,10,18,12,18,242,9,18,1,19,3,19,245,8,19,1,19,1,19,1,20,1,20,1,20,
+5,20,252,8,20,10,20,12,20,255,9,20,1,21,1,21,1,21,5,21,260,8,21,10,21,12,
+21,263,9,21,1,22,1,22,1,22,5,22,268,8,22,10,22,12,22,271,9,22,1,23,1,23,
+1,23,5,23,276,8,23,10,23,12,23,279,9,23,1,24,1,24,1,24,3,24,284,8,24,1,25,
+1,25,1,26,1,26,1,26,5,26,291,8,26,10,26,12,26,294,9,26,1,26,3,26,297,8,26,
+3,26,299,8,26,1,27,1,27,1,27,1,27,5,27,305,8,27,10,27,12,27,308,9,27,1,27,
+3,27,311,8,27,3,27,313,8,27,1,27,1,27,1,28,1,28,1,28,1,29,1,29,1,29,1,29,
+5,29,324,8,29,10,29,12,29,327,9,29,1,29,3,29,330,8,29,3,29,332,8,29,1,29,
+1,29,1,30,1,30,1,30,1,30,5,30,340,8,30,10,30,12,30,343,9,30,1,30,1,30,3,
+30,347,8,30,1,30,3,30,350,8,30,1,30,3,30,353,8,30,3,30,355,8,30,1,30,1,30,
+1,31,1,31,1,31,1,32,1,32,1,32,1,32,1,33,1,33,1,33,1,34,1,34,1,34,5,34,372,
+8,34,10,34,12,34,375,9,34,1,34,0,0,35,0,2,4,6,8,10,12,14,16,18,20,22,24,
+26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,0,3,1,
+0,37,38,1,0,35,36,1,0,39,44,399,0,74,1,0,0,0,2,82,1,0,0,0,4,88,1,0,0,0,6,
+90,1,0,0,0,8,103,1,0,0,0,10,105,1,0,0,0,12,111,1,0,0,0,14,124,1,0,0,0,16,
+133,1,0,0,0,18,154,1,0,0,0,20,176,1,0,0,0,22,178,1,0,0,0,24,198,1,0,0,0,
+26,207,1,0,0,0,28,212,1,0,0,0,30,214,1,0,0,0,32,217,1,0,0,0,34,227,1,0,0,
+0,36,235,1,0,0,0,38,244,1,0,0,0,40,248,1,0,0,0,42,256,1,0,0,0,44,264,1,0,
+0,0,46,272,1,0,0,0,48,280,1,0,0,0,50,285,1,0,0,0,52,298,1,0,0,0,54,300,1,
+0,0,0,56,316,1,0,0,0,58,319,1,0,0,0,60,335,1,0,0,0,62,358,1,0,0,0,64,361,
+1,0,0,0,66,365,1,0,0,0,68,368,1,0,0,0,70,73,3,8,4,0,71,73,3,4,2,0,72,70,
+1,0,0,0,72,71,1,0,0,0,73,76,1,0,0,0,74,72,1,0,0,0,74,75,1,0,0,0,75,77,1,
+0,0,0,76,74,1,0,0,0,77,78,5,0,0,1,78,1,1,0,0,0,79,81,3,8,4,0,80,79,1,0,0,
+0,81,84,1,0,0,0,82,80,1,0,0,0,82,83,1,0,0,0,83,85,1,0,0,0,84,82,1,0,0,0,
+85,86,3,50,25,0,86,87,5,0,0,1,87,3,1,0,0,0,88,89,3,6,3,0,89,5,1,0,0,0,90,
+91,5,22,0,0,91,92,5,15,0,0,92,93,3,68,34,0,93,95,3,60,30,0,94,96,3,66,33,
+0,95,94,1,0,0,0,95,96,1,0,0,0,96,97,1,0,0,0,97,98,5,1,0,0,98,7,1,0,0,0,99,
+104,3,10,5,0,100,104,3,12,6,0,101,104,3,14,7,0,102,104,3,16,8,0,103,99,1,
+0,0,0,103,100,1,0,0,0,103,101,1,0,0,0,103,102,1,0,0,0,104,9,1,0,0,0,105,
+106,5,20,0,0,106,109,3,68,34,0,107,110,5,1,0,0,108,110,3,54,27,0,109,107,
+1,0,0,0,109,108,1,0,0,0,110,11,1,0,0,0,111,112,5,15,0,0,112,113,3,68,34,
+0,113,115,3,58,29,0,114,116,3,66,33,0,115,114,1,0,0,0,115,116,1,0,0,0,116,
+122,1,0,0,0,117,118,5,2,0,0,118,119,3,50,25,0,119,120,5,1,0,0,120,123,1,
+0,0,0,121,123,3,32,16,0,122,117,1,0,0,0,122,121,1,0,0,0,123,13,1,0,0,0,124,
+125,5,16,0,0,125,127,3,68,34,0,126,128,3,66,33,0,127,126,1,0,0,0,127,128,
+1,0,0,0,128,129,1,0,0,0,129,130,5,2,0,0,130,131,3,50,25,0,131,132,5,1,0,
+0,132,15,1,0,0,0,133,134,5,21,0,0,134,135,3,68,34,0,135,149,5,3,0,0,136,
+141,3,18,9,0,137,138,5,4,0,0,138,140,3,18,9,0,139,137,1,0,0,0,140,143,1,
+0,0,0,141,139,1,0,0,0,141,142,1,0,0,0,142,145,1,0,0,0,143,141,1,0,0,0,144,
+146,5,4,0,0,145,144,1,0,0,0,145,146,1,0,0,0,146,148,1,0,0,0,147,136,1,0,
+0,0,148,151,1,0,0,0,149,147,1,0,0,0,149,150,1,0,0,0,150,152,1,0,0,0,151,
+149,1,0,0,0,152,153,5,5,0,0,153,17,1,0,0,0,154,156,5,34,0,0,155,157,3,54,
+27,0,156,155,1,0,0,0,156,157,1,0,0,0,157,19,1,0,0,0,158,177,5,26,0,0,159,
+177,5,27,0,0,160,177,5,28,0,0,161,177,5,29,0,0,162,177,5,30,0,0,163,177,
+5,31,0,0,164,177,5,32,0,0,165,177,5,33,0,0,166,177,3,22,11,0,167,177,3,34,
+17,0,168,177,3,26,13,0,169,177,3,28,14,0,170,177,3,30,15,0,171,177,3,32,
+16,0,172,173,5,6,0,0,173,174,3,50,25,0,174,175,5,7,0,0,175,177,1,0,0,0,176,
+158,1,0,0,0,176,159,1,0,0,0,176,160,1,0,0,0,176,161,1,0,0,0,176,162,1,0,
+0,0,176,163,1,0,0,0,176,164,1,0,0,0,176,165,1,0,0,0,176,166,1,0,0,0,176,
+167,1,0,0,0,176,168,1,0,0,0,176,169,1,0,0,0,176,170,1,0,0,0,176,171,1,0,
+0,0,176,172,1,0,0,0,177,21,1,0,0,0,178,179,5,17,0,0,179,180,3,50,25,0,180,
+192,5,3,0,0,181,186,3,24,12,0,182,183,5,4,0,0,183,185,3,24,12,0,184,182,
+1,0,0,0,185,188,1,0,0,0,186,184,1,0,0,0,186,187,1,0,0,0,187,190,1,0,0,0,
+188,186,1,0,0,0,189,191,5,4,0,0,190,189,1,0,0,0,190,191,1,0,0,0,191,193,
+1,0,0,0,192,181,1,0,0,0,192,193,1,0,0,0,193,194,1,0,0,0,194,195,5,5,0,0,
+195,23,1,0,0,0,196,199,5,25,0,0,197,199,3,50,25,0,198,196,1,0,0,0,198,197,
+1,0,0,0,199,202,1,0,0,0,200,201,5,14,0,0,201,203,5,34,0,0,202,200,1,0,0,
+0,202,203,1,0,0,0,203,204,1,0,0,0,204,205,5,8,0,0,205,206,3,50,25,0,206,
+25,1,0,0,0,207,208,3,68,34,0,208,209,5,6,0,0,209,210,3,52,26,0,210,211,5,
+7,0,0,211,27,1,0,0,0,212,213,3,68,34,0,213,29,1,0,0,0,214,215,3,68,34,0,
+215,216,3,54,27,0,216,31,1,0,0,0,217,221,5,3,0,0,218,220,3,8,4,0,219,218,
+1,0,0,0,220,223,1,0,0,0,221,219,1,0,0,0,221,222,1,0,0,0,222,224,1,0,0,0,
+223,221,1,0,0,0,224,225,3,50,25,0,225,226,5,5,0,0,226,33,1,0,0,0,227,228,
+5,18,0,0,228,229,3,50,25,0,229,230,3,32,16,0,230,233,5,19,0,0,231,234,3,
+32,16,0,232,234,3,34,17,0,233,231,1,0,0,0,233,232,1,0,0,0,234,35,1,0,0,0,
+235,240,3,20,10,0,236,237,5,9,0,0,237,239,5,34,0,0,238,236,1,0,0,0,239,242,
+1,0,0,0,240,238,1,0,0,0,240,241,1,0,0,0,241,37,1,0,0,0,242,240,1,0,0,0,243,
+245,5,35,0,0,244,243,1,0,0,0,244,245,1,0,0,0,245,246,1,0,0,0,246,247,3,36,
+18,0,247,39,1,0,0,0,248,253,3,38,19,0,249,250,7,0,0,0,250,252,3,38,19,0,
+251,249,1,0,0,0,252,255,1,0,0,0,253,251,1,0,0,0,253,254,1,0,0,0,254,41,1,
+0,0,0,255,253,1,0,0,0,256,261,3,40,20,0,257,258,7,1,0,0,258,260,3,40,20,
+0,259,257,1,0,0,0,260,263,1,0,0,0,261,259,1,0,0,0,261,262,1,0,0,0,262,43,
+1,0,0,0,263,261,1,0,0,0,264,269,3,42,21,0,265,266,5,10,0,0,266,268,3,42,
+21,0,267,265,1,0,0,0,268,271,1,0,0,0,269,267,1,0,0,0,269,270,1,0,0,0,270,
+45,1,0,0,0,271,269,1,0,0,0,272,277,3,44,22,0,273,274,5,11,0,0,274,276,3,
+44,22,0,275,273,1,0,0,0,276,279,1,0,0,0,277,275,1,0,0,0,277,278,1,0,0,0,
+278,47,1,0,0,0,279,277,1,0,0,0,280,283,3,46,23,0,281,282,7,2,0,0,282,284,
+3,46,23,0,283,281,1,0,0,0,283,284,1,0,0,0,284,49,1,0,0,0,285,286,3,48,24,
+0,286,51,1,0,0,0,287,292,3,50,25,0,288,289,5,4,0,0,289,291,3,50,25,0,290,
+288,1,0,0,0,291,294,1,0,0,0,292,290,1,0,0,0,292,293,1,0,0,0,293,296,1,0,
+0,0,294,292,1,0,0,0,295,297,5,4,0,0,296,295,1,0,0,0,296,297,1,0,0,0,297,
+299,1,0,0,0,298,287,1,0,0,0,298,299,1,0,0,0,299,53,1,0,0,0,300,312,5,3,0,
+0,301,306,3,56,28,0,302,303,5,4,0,0,303,305,3,56,28,0,304,302,1,0,0,0,305,
+308,1,0,0,0,306,304,1,0,0,0,306,307,1,0,0,0,307,310,1,0,0,0,308,306,1,0,
+0,0,309,311,5,4,0,0,310,309,1,0,0,0,310,311,1,0,0,0,311,313,1,0,0,0,312,
+301,1,0,0,0,312,313,1,0,0,0,313,314,1,0,0,0,314,315,5,5,0,0,315,55,1,0,0,
+0,316,317,5,34,0,0,317,318,3,66,33,0,318,57,1,0,0,0,319,331,5,6,0,0,320,
+325,3,62,31,0,321,322,5,4,0,0,322,324,3,62,31,0,323,321,1,0,0,0,324,327,
+1,0,0,0,325,323,1,0,0,0,325,326,1,0,0,0,326,329,1,0,0,0,327,325,1,0,0,0,
+328,330,5,4,0,0,329,328,1,0,0,0,329,330,1,0,0,0,330,332,1,0,0,0,331,320,
+1,0,0,0,331,332,1,0,0,0,332,333,1,0,0,0,333,334,5,7,0,0,334,59,1,0,0,0,335,
+354,5,6,0,0,336,341,3,62,31,0,337,338,5,4,0,0,338,340,3,62,31,0,339,337,
+1,0,0,0,340,343,1,0,0,0,341,339,1,0,0,0,341,342,1,0,0,0,342,346,1,0,0,0,
+343,341,1,0,0,0,344,345,5,4,0,0,345,347,3,64,32,0,346,344,1,0,0,0,346,347,
+1,0,0,0,347,350,1,0,0,0,348,350,3,64,32,0,349,336,1,0,0,0,349,348,1,0,0,
+0,350,352,1,0,0,0,351,353,5,4,0,0,352,351,1,0,0,0,352,353,1,0,0,0,353,355,
+1,0,0,0,354,349,1,0,0,0,354,355,1,0,0,0,355,356,1,0,0,0,356,357,5,7,0,0,
+357,61,1,0,0,0,358,359,5,34,0,0,359,360,3,66,33,0,360,63,1,0,0,0,361,362,
+5,45,0,0,362,363,5,34,0,0,363,364,3,66,33,0,364,65,1,0,0,0,365,366,5,12,
+0,0,366,367,3,50,25,0,367,67,1,0,0,0,368,373,5,34,0,0,369,370,5,13,0,0,370,
+372,5,34,0,0,371,369,1,0,0,0,372,375,1,0,0,0,373,371,1,0,0,0,373,374,1,0,
+0,0,374,69,1,0,0,0,375,373,1,0,0,0,43,72,74,82,95,103,109,115,122,127,141,
+145,149,156,176,186,190,192,198,202,221,233,240,244,253,261,269,277,283,
+292,296,298,306,310,312,325,329,331,341,346,349,352,354,373];
 
 
 const atn = new antlr4.atn.ATNDeserializer().deserialize(serializedATN);
@@ -970,8 +971,20 @@ export default class NaviParser extends antlr4.Parser {
 	        this.scopeExpression();
 	        this.state = 230;
 	        this.match(NaviParser.Else);
-	        this.state = 231;
-	        this.scopeExpression();
+	        this.state = 233;
+	        this._errHandler.sync(this);
+	        switch(this._input.LA(1)) {
+	        case NaviParser.T__2:
+	            this.state = 231;
+	            this.scopeExpression();
+	            break;
+	        case NaviParser.If:
+	            this.state = 232;
+	            this.ifExpression();
+	            break;
+	        default:
+	            throw new antlr4.error.NoViableAltException(this);
+	        }
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
 		        localctx.exception = re;
@@ -994,17 +1007,17 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 233;
+	        this.state = 235;
 	        this.primaryExpression();
-	        this.state = 238;
+	        this.state = 240;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        while(_la===NaviParser.T__8) {
-	            this.state = 234;
+	            this.state = 236;
 	            this.match(NaviParser.T__8);
-	            this.state = 235;
+	            this.state = 237;
 	            this.match(NaviParser.Identifier);
-	            this.state = 240;
+	            this.state = 242;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	        }
@@ -1030,15 +1043,15 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 242;
+	        this.state = 244;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        if(_la===NaviParser.OpMinus) {
-	            this.state = 241;
+	            this.state = 243;
 	            this.match(NaviParser.OpMinus);
 	        }
 
-	        this.state = 244;
+	        this.state = 246;
 	        this.fieldAccessExpression();
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1062,13 +1075,13 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 246;
+	        this.state = 248;
 	        this.negateExpression();
-	        this.state = 251;
+	        this.state = 253;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        while(_la===NaviParser.OpMult || _la===NaviParser.OpDiv) {
-	            this.state = 247;
+	            this.state = 249;
 	            _la = this._input.LA(1);
 	            if(!(_la===NaviParser.OpMult || _la===NaviParser.OpDiv)) {
 	            this._errHandler.recoverInline(this);
@@ -1077,9 +1090,9 @@ export default class NaviParser extends antlr4.Parser {
 	            	this._errHandler.reportMatch(this);
 	                this.consume();
 	            }
-	            this.state = 248;
+	            this.state = 250;
 	            this.negateExpression();
-	            this.state = 253;
+	            this.state = 255;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	        }
@@ -1105,13 +1118,13 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 254;
+	        this.state = 256;
 	        this.multiplicativeExpression();
-	        this.state = 259;
+	        this.state = 261;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        while(_la===NaviParser.OpMinus || _la===NaviParser.OpPlus) {
-	            this.state = 255;
+	            this.state = 257;
 	            _la = this._input.LA(1);
 	            if(!(_la===NaviParser.OpMinus || _la===NaviParser.OpPlus)) {
 	            this._errHandler.recoverInline(this);
@@ -1120,9 +1133,9 @@ export default class NaviParser extends antlr4.Parser {
 	            	this._errHandler.reportMatch(this);
 	                this.consume();
 	            }
-	            this.state = 256;
+	            this.state = 258;
 	            this.multiplicativeExpression();
-	            this.state = 261;
+	            this.state = 263;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	        }
@@ -1148,17 +1161,17 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 262;
+	        this.state = 264;
 	        this.additiveExpression();
-	        this.state = 267;
+	        this.state = 269;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        while(_la===NaviParser.T__9) {
-	            this.state = 263;
+	            this.state = 265;
 	            this.match(NaviParser.T__9);
-	            this.state = 264;
+	            this.state = 266;
 	            this.additiveExpression();
-	            this.state = 269;
+	            this.state = 271;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	        }
@@ -1184,17 +1197,17 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 270;
+	        this.state = 272;
 	        this.intersectionExpression();
-	        this.state = 275;
+	        this.state = 277;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        while(_la===NaviParser.T__10) {
-	            this.state = 271;
+	            this.state = 273;
 	            this.match(NaviParser.T__10);
-	            this.state = 272;
+	            this.state = 274;
 	            this.intersectionExpression();
-	            this.state = 277;
+	            this.state = 279;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	        }
@@ -1220,13 +1233,13 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 278;
+	        this.state = 280;
 	        this.unionExpression();
-	        this.state = 281;
+	        this.state = 283;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        if(((((_la - 39)) & ~0x1f) == 0 && ((1 << (_la - 39)) & ((1 << (NaviParser.OpEqual - 39)) | (1 << (NaviParser.OpNotEqual - 39)) | (1 << (NaviParser.OpGt - 39)) | (1 << (NaviParser.OpLt - 39)) | (1 << (NaviParser.OpGte - 39)) | (1 << (NaviParser.OpLte - 39)))) !== 0)) {
-	            this.state = 279;
+	            this.state = 281;
 	            _la = this._input.LA(1);
 	            if(!(((((_la - 39)) & ~0x1f) == 0 && ((1 << (_la - 39)) & ((1 << (NaviParser.OpEqual - 39)) | (1 << (NaviParser.OpNotEqual - 39)) | (1 << (NaviParser.OpGt - 39)) | (1 << (NaviParser.OpLt - 39)) | (1 << (NaviParser.OpGte - 39)) | (1 << (NaviParser.OpLte - 39)))) !== 0))) {
 	            this._errHandler.recoverInline(this);
@@ -1235,7 +1248,7 @@ export default class NaviParser extends antlr4.Parser {
 	            	this._errHandler.reportMatch(this);
 	                this.consume();
 	            }
-	            this.state = 280;
+	            this.state = 282;
 	            this.unionExpression();
 	        }
 
@@ -1260,7 +1273,7 @@ export default class NaviParser extends antlr4.Parser {
 	    this.enterRule(localctx, 50, NaviParser.RULE_expression);
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 283;
+	        this.state = 285;
 	        this.comparisonExpression();
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1284,32 +1297,32 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 296;
+	        this.state = 298;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        if((((_la) & ~0x1f) == 0 && ((1 << _la) & ((1 << NaviParser.T__2) | (1 << NaviParser.T__5) | (1 << NaviParser.Match) | (1 << NaviParser.If) | (1 << NaviParser.IntInterval) | (1 << NaviParser.NonIntInterval) | (1 << NaviParser.IntervalInclusive) | (1 << NaviParser.IntervalMinExclusive) | (1 << NaviParser.IntervalMaxExclusive) | (1 << NaviParser.IntervalExclusive))) !== 0) || ((((_la - 32)) & ~0x1f) == 0 && ((1 << (_la - 32)) & ((1 << (NaviParser.Number - 32)) | (1 << (NaviParser.String - 32)) | (1 << (NaviParser.Identifier - 32)) | (1 << (NaviParser.OpMinus - 32)))) !== 0)) {
-	            this.state = 285;
+	            this.state = 287;
 	            this.expression();
-	            this.state = 290;
+	            this.state = 292;
 	            this._errHandler.sync(this);
-	            var _alt = this._interp.adaptivePredict(this._input,27,this._ctx)
+	            var _alt = this._interp.adaptivePredict(this._input,28,this._ctx)
 	            while(_alt!=2 && _alt!=antlr4.atn.ATN.INVALID_ALT_NUMBER) {
 	                if(_alt===1) {
-	                    this.state = 286;
+	                    this.state = 288;
 	                    this.match(NaviParser.T__3);
-	                    this.state = 287;
+	                    this.state = 289;
 	                    this.expression(); 
 	                }
-	                this.state = 292;
+	                this.state = 294;
 	                this._errHandler.sync(this);
-	                _alt = this._interp.adaptivePredict(this._input,27,this._ctx);
+	                _alt = this._interp.adaptivePredict(this._input,28,this._ctx);
 	            }
 
-	            this.state = 294;
+	            this.state = 296;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	            if(_la===NaviParser.T__3) {
-	                this.state = 293;
+	                this.state = 295;
 	                this.match(NaviParser.T__3);
 	            }
 
@@ -1337,40 +1350,40 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 298;
+	        this.state = 300;
 	        this.match(NaviParser.T__2);
-	        this.state = 310;
+	        this.state = 312;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        if(_la===NaviParser.Identifier) {
-	            this.state = 299;
+	            this.state = 301;
 	            this.field();
-	            this.state = 304;
+	            this.state = 306;
 	            this._errHandler.sync(this);
-	            var _alt = this._interp.adaptivePredict(this._input,30,this._ctx)
+	            var _alt = this._interp.adaptivePredict(this._input,31,this._ctx)
 	            while(_alt!=2 && _alt!=antlr4.atn.ATN.INVALID_ALT_NUMBER) {
 	                if(_alt===1) {
-	                    this.state = 300;
+	                    this.state = 302;
 	                    this.match(NaviParser.T__3);
-	                    this.state = 301;
+	                    this.state = 303;
 	                    this.field(); 
 	                }
-	                this.state = 306;
+	                this.state = 308;
 	                this._errHandler.sync(this);
-	                _alt = this._interp.adaptivePredict(this._input,30,this._ctx);
+	                _alt = this._interp.adaptivePredict(this._input,31,this._ctx);
 	            }
 
-	            this.state = 308;
+	            this.state = 310;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	            if(_la===NaviParser.T__3) {
-	                this.state = 307;
+	                this.state = 309;
 	                this.match(NaviParser.T__3);
 	            }
 
 	        }
 
-	        this.state = 312;
+	        this.state = 314;
 	        this.match(NaviParser.T__4);
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1393,9 +1406,9 @@ export default class NaviParser extends antlr4.Parser {
 	    this.enterRule(localctx, 56, NaviParser.RULE_field);
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 314;
+	        this.state = 316;
 	        this.match(NaviParser.Identifier);
-	        this.state = 315;
+	        this.state = 317;
 	        this.assert();
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1419,40 +1432,40 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 317;
+	        this.state = 319;
 	        this.match(NaviParser.T__5);
-	        this.state = 329;
+	        this.state = 331;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        if(_la===NaviParser.Identifier) {
-	            this.state = 318;
+	            this.state = 320;
 	            this.parameter();
-	            this.state = 323;
+	            this.state = 325;
 	            this._errHandler.sync(this);
-	            var _alt = this._interp.adaptivePredict(this._input,33,this._ctx)
+	            var _alt = this._interp.adaptivePredict(this._input,34,this._ctx)
 	            while(_alt!=2 && _alt!=antlr4.atn.ATN.INVALID_ALT_NUMBER) {
 	                if(_alt===1) {
-	                    this.state = 319;
+	                    this.state = 321;
 	                    this.match(NaviParser.T__3);
-	                    this.state = 320;
+	                    this.state = 322;
 	                    this.parameter(); 
 	                }
-	                this.state = 325;
+	                this.state = 327;
 	                this._errHandler.sync(this);
-	                _alt = this._interp.adaptivePredict(this._input,33,this._ctx);
+	                _alt = this._interp.adaptivePredict(this._input,34,this._ctx);
 	            }
 
-	            this.state = 327;
+	            this.state = 329;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	            if(_la===NaviParser.T__3) {
-	                this.state = 326;
+	                this.state = 328;
 	                this.match(NaviParser.T__3);
 	            }
 
 	        }
 
-	        this.state = 331;
+	        this.state = 333;
 	        this.match(NaviParser.T__6);
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1476,62 +1489,62 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 333;
+	        this.state = 335;
 	        this.match(NaviParser.T__5);
-	        this.state = 352;
+	        this.state = 354;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        if(_la===NaviParser.Identifier || _la===NaviParser.OpSpread) {
-	            this.state = 347;
+	            this.state = 349;
 	            this._errHandler.sync(this);
 	            switch(this._input.LA(1)) {
 	            case NaviParser.Identifier:
-	                this.state = 334;
+	                this.state = 336;
 	                this.parameter();
-	                this.state = 339;
+	                this.state = 341;
 	                this._errHandler.sync(this);
-	                var _alt = this._interp.adaptivePredict(this._input,36,this._ctx)
+	                var _alt = this._interp.adaptivePredict(this._input,37,this._ctx)
 	                while(_alt!=2 && _alt!=antlr4.atn.ATN.INVALID_ALT_NUMBER) {
 	                    if(_alt===1) {
-	                        this.state = 335;
+	                        this.state = 337;
 	                        this.match(NaviParser.T__3);
-	                        this.state = 336;
+	                        this.state = 338;
 	                        this.parameter(); 
 	                    }
-	                    this.state = 341;
+	                    this.state = 343;
 	                    this._errHandler.sync(this);
-	                    _alt = this._interp.adaptivePredict(this._input,36,this._ctx);
+	                    _alt = this._interp.adaptivePredict(this._input,37,this._ctx);
 	                }
 
-	                this.state = 344;
+	                this.state = 346;
 	                this._errHandler.sync(this);
-	                var la_ = this._interp.adaptivePredict(this._input,37,this._ctx);
+	                var la_ = this._interp.adaptivePredict(this._input,38,this._ctx);
 	                if(la_===1) {
-	                    this.state = 342;
+	                    this.state = 344;
 	                    this.match(NaviParser.T__3);
-	                    this.state = 343;
+	                    this.state = 345;
 	                    this.varArgParameter();
 
 	                }
 	                break;
 	            case NaviParser.OpSpread:
-	                this.state = 346;
+	                this.state = 348;
 	                this.varArgParameter();
 	                break;
 	            default:
 	                throw new antlr4.error.NoViableAltException(this);
 	            }
-	            this.state = 350;
+	            this.state = 352;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	            if(_la===NaviParser.T__3) {
-	                this.state = 349;
+	                this.state = 351;
 	                this.match(NaviParser.T__3);
 	            }
 
 	        }
 
-	        this.state = 354;
+	        this.state = 356;
 	        this.match(NaviParser.T__6);
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1554,9 +1567,9 @@ export default class NaviParser extends antlr4.Parser {
 	    this.enterRule(localctx, 62, NaviParser.RULE_parameter);
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 356;
+	        this.state = 358;
 	        this.match(NaviParser.Identifier);
-	        this.state = 357;
+	        this.state = 359;
 	        this.assert();
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1579,11 +1592,11 @@ export default class NaviParser extends antlr4.Parser {
 	    this.enterRule(localctx, 64, NaviParser.RULE_varArgParameter);
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 359;
-	        this.match(NaviParser.OpSpread);
-	        this.state = 360;
-	        this.match(NaviParser.Identifier);
 	        this.state = 361;
+	        this.match(NaviParser.OpSpread);
+	        this.state = 362;
+	        this.match(NaviParser.Identifier);
+	        this.state = 363;
 	        this.assert();
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1606,9 +1619,9 @@ export default class NaviParser extends antlr4.Parser {
 	    this.enterRule(localctx, 66, NaviParser.RULE_assert);
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 363;
+	        this.state = 365;
 	        this.match(NaviParser.T__11);
-	        this.state = 364;
+	        this.state = 366;
 	        this.expression();
 	    } catch (re) {
 	    	if(re instanceof antlr4.error.RecognitionException) {
@@ -1632,17 +1645,17 @@ export default class NaviParser extends antlr4.Parser {
 	    var _la = 0; // Token type
 	    try {
 	        this.enterOuterAlt(localctx, 1);
-	        this.state = 366;
+	        this.state = 368;
 	        this.match(NaviParser.Identifier);
-	        this.state = 371;
+	        this.state = 373;
 	        this._errHandler.sync(this);
 	        _la = this._input.LA(1);
 	        while(_la===NaviParser.T__12) {
-	            this.state = 367;
+	            this.state = 369;
 	            this.match(NaviParser.T__12);
-	            this.state = 368;
+	            this.state = 370;
 	            this.match(NaviParser.Identifier);
-	            this.state = 373;
+	            this.state = 375;
 	            this._errHandler.sync(this);
 	            _la = this._input.LA(1);
 	        }
@@ -2612,6 +2625,10 @@ class IfExpressionContext extends antlr4.ParserRuleContext {
 
 	Else() {
 	    return this.getToken(NaviParser.Else, 0);
+	};
+
+	ifExpression() {
+	    return this.getTypedRuleContext(IfExpressionContext,0);
 	};
 
 	enterRule(listener) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -531,13 +531,22 @@ class AstConverter {
         }
         if (context instanceof NaviParser.IfExpressionContext) {
             const condition = this.toExpression(getRequired(context, 'expression'));
-            const [trueBranch, falseBranch] = getMultiple(context, 'scopeExpression').map(
-                this.toExpression
-            );
-            return new MatchExpression(condition, [
-                new MatchArm(BOOL_TRUE, undefined, trueBranch),
-                new MatchArm(BOOL_FALSE, undefined, falseBranch),
-            ]);
+            const elseIf = getOptional(context, 'ifExpression');
+            if (elseIf) {
+                const [trueBranch] = getMultiple(context, 'scopeExpression').map(this.toExpression);
+                return new MatchExpression(condition, [
+                    new MatchArm(BOOL_TRUE, undefined, trueBranch),
+                    new MatchArm(BOOL_FALSE, undefined, this.toExpression(elseIf)),
+                ]);
+            } else {
+                const [trueBranch, falseBranch] = getMultiple(context, 'scopeExpression').map(
+                    this.toExpression
+                );
+                return new MatchExpression(condition, [
+                    new MatchArm(BOOL_TRUE, undefined, trueBranch),
+                    new MatchArm(BOOL_FALSE, undefined, falseBranch),
+                ]);
+            }
         }
 
         return assertNever(context);

--- a/tests/__snapshots__/parse.test.ts.snap
+++ b/tests/__snapshots__/parse.test.ts.snap
@@ -302,6 +302,9 @@ match a { true => 1, false => 2 }
 >>> if (a) { 1 } else { 2 }
 match a { true => 1, false => 2 }
 
+>>> if a { 1 } else if b { 2 } else { 3}
+match a { true => 1, false => match b { true => 2, false => 3 } }
+
 >>> a.b.c.d.e.f
 a.b.c.d.e.f
 
@@ -560,6 +563,9 @@ SyntaxError: At 1:5: missing '{' at '1'
 
 >>> if a { 2 }
 SyntaxError: At 1:10: mismatched input '<EOF>' expecting 'else'
+
+>>> if a { 2 } else if b { 3 }
+SyntaxError: At 1:26: mismatched input '<EOF>' expecting 'else'
 
 >>> a.match
 SyntaxError: At 1:2: mismatched input 'match' expecting Identifier

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -125,6 +125,7 @@ const expressionSnippets: string[] = [
     // if
     String.raw`if a { 1 } else { 2 }`,
     String.raw`if (a) { 1 } else { 2 }`,
+    String.raw`if a { 1 } else if b { 2 } else { 3}`,
 
     // field access
     String.raw`a.b.c.d.e.f`,
@@ -251,6 +252,7 @@ const invalidExpressionSnippets: string[] = [
     String.raw`if a`,
     String.raw`if a 1 else 2`,
     String.raw`if a { 2 }`,
+    String.raw`if a { 2 } else if b { 3 }`,
 
     // field access
     String.raw`a.match`,


### PR DESCRIPTION
I added support for `else if` chains. While the functionality of `if a { 1 } else if b { 2 } else { 3 }` was previously possible to express as `if a { 1 } else { if b { 2 } else { 3 } }`, `else-if` chains are just nicer to write and read.